### PR TITLE
Prevent the constant loading of the image when playing content

### DIFF
--- a/now-playing-card.js
+++ b/now-playing-card.js
@@ -43,10 +43,14 @@ class NowPlayingPoster extends HTMLElement {
 			}
 			else
 			{
-			this.content.innerHTML = `
-			<!-- now playing card ${entityId}  -->
-			<img src="${movposter}" width=100% height=100%">
-			`;
+				const img = new Image();
+				img.onload = () => {
+					this.content.innerHTML = `
+					<!-- now playing card ${entityId}  -->
+					<img src="${movposter}" width=100% height=100%">
+					`;
+				};
+				img['src']= movposter
 			}
 		}
 		else


### PR DESCRIPTION
When playing a content the image is going to change every time that the state changes, and because the images was loading once rendered on the page, it was rendering every few second, witch mean it was loading almost all the time.
To prevent this issue we could preload the image outside the DOM and the insert the image on the DOM, with means replaze a loaded image with another loaded image